### PR TITLE
Configure whether or not puppet should run statsd.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,7 @@ class statsd(
   $init_script      = $statsd::params::init_script,
   $node_manage      = $statsd::params::node_manage,
   $node_version     = $statsd::params::node_version,
+  $manage_service   = $statsd::params::manage_service,
 ) inherits statsd::params {
 
   if $node_manage == true {
@@ -70,10 +71,15 @@ class statsd(
   }
 
   service { 'statsd':
-    ensure    => running,
     enable    => true,
     hasstatus => true,
     pattern   => 'node .*stats.js',
     require   => File['/var/log/statsd'],
+  }
+
+  if $manage_service == true {
+    Service['statsd'] {
+      ensure  => running,
+    }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class statsd::params {
   $node_module_dir  = ''
   $node_manage      = true
   $node_version     = 'present'
+  $manage_service   = true
 
   case $::osfamily {
     'RedHat': {


### PR DESCRIPTION
By default, puppet should ensure statsd is running.

Background: I typically delegate the management of services to something like monit. This change preserves the existing behavior, but allows for _not_ having puppet ensure statsd is running.